### PR TITLE
adds alt="$...$" attribute for accessibility

### DIFF
--- a/readme2tex/render.py
+++ b/readme2tex/render.py
@@ -25,6 +25,16 @@ try:
 except NameError:
     pass
 
+html_escape_dict = {
+    '"': '&quot;',
+    '\n': '&#x0a;',
+    '<': '&lt;',
+}
+
+def replace_all(text, dic):
+  for i, j in dic.iteritems():
+    text = text.replace(i, j)
+  return text
 
 def rendertex(engine, string, packages, temp_dir, block):
     if engine != 'latex': raise Exception("Not Implemented")
@@ -317,7 +327,8 @@ def render(
             tail.append('%x' % random.randint(0, 1e12))
         if needs_inversion:
             tail.append('invert_in_darkmode')
-        img = '<img src="%s%s" %s width=%spt height=%spt/>' % (
+        img = '<img alt="%s" src="%s%s" %s width="%spt" height="%spt"/>' % (
+            replace_all(equation, html_escape_dict),
             url,
             '?%s' % ('&'.join(tail)) if tail else '',
             ('valign=%spx'%(-off * scale) if use_valign else 'align=middle'),

--- a/readme2tex/render.py
+++ b/readme2tex/render.py
@@ -7,6 +7,7 @@ import sys
 import tempfile
 import xml.etree.ElementTree as ET
 from subprocess import check_output
+from xml.sax.saxutils import quoteattr
 import logging
 
 envelope = r'''%% processed with readme2tex
@@ -24,17 +25,6 @@ try:
     input = raw_input
 except NameError:
     pass
-
-html_escape_dict = {
-    '"': '&quot;',
-    '\n': '&#x0a;',
-    '<': '&lt;',
-}
-
-def replace_all(text, dic):
-  for i, j in dic.iteritems():
-    text = text.replace(i, j)
-  return text
 
 def rendertex(engine, string, packages, temp_dir, block):
     if engine != 'latex': raise Exception("Not Implemented")
@@ -327,8 +317,8 @@ def render(
             tail.append('%x' % random.randint(0, 1e12))
         if needs_inversion:
             tail.append('invert_in_darkmode')
-        img = '<img alt="%s" src="%s%s" %s width="%spt" height="%spt"/>' % (
-            replace_all(equation, html_escape_dict),
+        img = '<img alt=%s src="%s%s" %s width="%spt" height="%spt"/>' % (
+            quoteattr(equation),
             url,
             '?%s' % ('&'.join(tail)) if tail else '',
             ('valign=%spx'%(-off * scale) if use_valign else 'align=middle'),


### PR DESCRIPTION
Thanks for this library! I was thinking of using it for https://github.com/philschatz/textbooks . That way the math in the books can be viewed/edited on GitHub as well as on the `gh-pages` site (see [blog post](http://philschatz.com/2014/07/07/tiny-book-reader/) )

This adds an `alt="$...$'` attribute to images for accessibility. Then, as another Pull Request I could add support for editing the alt attribute directly instead of using `$$` delimiters (since the canonical source of the formula would be in the `alt="$...$"` attribute).

# Example

[Here is an example `README.md` rendered using this code](https://github.com/philschatz/readme2tex/tree/adds-alt-text-test)

## Screenshot

![image](https://cloud.githubusercontent.com/assets/253202/21790442/4d870404-d6aa-11e6-9695-63335921aa33.png)
