### PR TITLE
generates image links for jsDelivr instead of RawGit (deprecated)

### DIFF
--- a/readme2tex/render.py
+++ b/readme2tex/render.py
@@ -309,7 +309,7 @@ def render(
     if nocdn:
         svg_url = "{svgdir}/{name}.svg"
     else:
-        svg_url = "https://rawgit.com/{user}/{project}/{branch}/{svgdir}/{name}.svg"
+        svg_url = "https://cdn.jsdelivr.net/gh/{user}/{project}@{branch}/{svgdir}/{name}.svg"
 
     if pngtrick:
         svg_url = svg_url[:-4] + '.png'


### PR DESCRIPTION
[RawGit](https://rawgit.com/) shut down for new repositories as of October 2019, so instead image links are generated for [jsDelivr](https://www.jsdelivr.com/)