### PR TITLE
Add cdnurl option for specifying base address of images

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ In addition, you can specify other arguments to `render.py`, such as:
 * `--project project` The current github project. This is also optional.
 * `--nocdn` Ticking this will use relative paths for the output images. Defaults to False.
 * `--cdnurl url` The CDN used for the images. Defaults to `https://cdn.jsdelivr.net/gh`.
+* `--cdnrefsep sep` The separator used by the CDN to separate project and reference. Defaults to `@`.
 * `--htmlize` Ticking this will output a `md.html` file so you can preview what the output looks like. Defaults to False.
 * `--valign` Ticking this will use the `valign` trick (detailed below) instead. See the caveats section for tradeoffs.
 * `--rerender` Ticking this will force a recompilation of all <img alt="$\text{\LaTeX}$" src="svgs/c068b57af6b6fa949824f73dcb828783.png?invert_in_darkmode" align=middle width="42.05817pt" height="22.407pt"/> formulas even if they are already cached.

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ In addition, you can specify other arguments to `render.py`, such as:
 * `--username username` Your github username. This is optional, and `render.py` will try to infer this for you.
 * `--project project` The current github project. This is also optional.
 * `--nocdn` Ticking this will use relative paths for the output images. Defaults to False.
+* `--cdnurl url` The CDN used for the images. Defaults to `https://cdn.jsdelivr.net/gh`.
 * `--htmlize` Ticking this will output a `md.html` file so you can preview what the output looks like. Defaults to False.
 * `--valign` Ticking this will use the `valign` trick (detailed below) instead. See the caveats section for tradeoffs.
 * `--rerender` Ticking this will force a recompilation of all <img alt="$\text{\LaTeX}$" src="svgs/c068b57af6b6fa949824f73dcb828783.png?invert_in_darkmode" align=middle width="42.05817pt" height="22.407pt"/> formulas even if they are already cached.

--- a/readme2tex/__main__.py
+++ b/readme2tex/__main__.py
@@ -131,6 +131,7 @@ To save this script as your post-commit git hook, run
     parser.add_argument('--add-git-hook', action='store_true', help="Automatically generates a post-commit git hook with the rest of the arguments. In the future, git commit will automatically trigger readme2tex if the input file is changed.")
     parser.add_argument('--pngtrick', action='store_true', help="Convert output to png.")
     parser.add_argument('input', nargs='?', type=str, help="Same as --readme")
+    parser.add_argument('--cdnurl', type=str, default='https://cdn.jsdelivr.net/gh', help="URL of the CDN to use. Defaults to https://cdn.jsdelivr.net/gh.")
 
     args = parser.parse_args()
     if args.input:
@@ -159,7 +160,8 @@ To save this script as your post-commit git hook, run
             args.valign,
             args.rerender,
             args.pngtrick,
-            args.bustcache)
+            args.bustcache,
+            args.cdnurl)
     else:
 
         # Move ourselves to the root of the current repository

--- a/readme2tex/__main__.py
+++ b/readme2tex/__main__.py
@@ -132,6 +132,7 @@ To save this script as your post-commit git hook, run
     parser.add_argument('--pngtrick', action='store_true', help="Convert output to png.")
     parser.add_argument('input', nargs='?', type=str, help="Same as --readme")
     parser.add_argument('--cdnurl', type=str, default='https://cdn.jsdelivr.net/gh', help="URL of the CDN to use. Defaults to https://cdn.jsdelivr.net/gh.")
+    parser.add_argument('--cdnrefsep', type=str, default='@', help="Separator between project and reference in CDN URL. Defaults to @.")
 
     args = parser.parse_args()
     if args.input:
@@ -161,7 +162,8 @@ To save this script as your post-commit git hook, run
             args.rerender,
             args.pngtrick,
             args.bustcache,
-            args.cdnurl)
+            args.cdnurl,
+            args.cdnrefsep)
     else:
 
         # Move ourselves to the root of the current repository

--- a/readme2tex/render.py
+++ b/readme2tex/render.py
@@ -127,7 +127,8 @@ def render(
         use_valign=False,
         rerender=False,
         pngtrick=False,
-        bustcache=False):
+        bustcache=False,
+        cdnurl='https://cdn.jsdelivr.net/gh'):
     # look for $.$ or $$.$$
     if htmlize:
         nocdn = True
@@ -309,7 +310,7 @@ def render(
     if nocdn:
         svg_url = "{svgdir}/{name}.svg"
     else:
-        svg_url = "https://cdn.jsdelivr.net/gh/{user}/{project}@{branch}/{svgdir}/{name}.svg"
+        svg_url = "{cdnurl}/{user}/{project}/{branch}/{svgdir}/{name}.svg"
 
     if pngtrick:
         svg_url = svg_url[:-4] + '.png'
@@ -325,7 +326,7 @@ def render(
         scale = 1.65
         height = float(attributes['height'][:-2]) * scale
         width = float(attributes['width'][:-2]) * scale
-        url = svg_url.format(user=user, project=project, branch=branch, svgdir=svgdir, name=name)
+        url = svg_url.format(cdnurl=cdnurl, user=user, project=project, branch=branch, svgdir=svgdir, name=name)
         tail = []
         if bustcache:
             tail.append('%x' % random.randint(0, 1e12))

--- a/readme2tex/render.py
+++ b/readme2tex/render.py
@@ -128,7 +128,8 @@ def render(
         rerender=False,
         pngtrick=False,
         bustcache=False,
-        cdnurl='https://cdn.jsdelivr.net/gh'):
+        cdnurl='https://cdn.jsdelivr.net/gh'.
+        cdnrefsep='@'):
     # look for $.$ or $$.$$
     if htmlize:
         nocdn = True
@@ -310,7 +311,7 @@ def render(
     if nocdn:
         svg_url = "{svgdir}/{name}.svg"
     else:
-        svg_url = "{cdnurl}/{user}/{project}/{branch}/{svgdir}/{name}.svg"
+        svg_url = "{cdnurl}/{user}/{project}{cdnrefsep}{branch}/{svgdir}/{name}.svg"
 
     if pngtrick:
         svg_url = svg_url[:-4] + '.png'
@@ -326,7 +327,7 @@ def render(
         scale = 1.65
         height = float(attributes['height'][:-2]) * scale
         width = float(attributes['width'][:-2]) * scale
-        url = svg_url.format(cdnurl=cdnurl, user=user, project=project, branch=branch, svgdir=svgdir, name=name)
+        url = svg_url.format(cdnurl=cdnurl, cdnrefsep=cdnrefsep, user=user, project=project, branch=branch, svgdir=svgdir, name=name)
         tail = []
         if bustcache:
             tail.append('%x' % random.randint(0, 1e12))


### PR DESCRIPTION
Adds options to specify CDN used for generated images in order to replace the default value `https://cdn.jsdelivr.net/gh` with e.g. `https://raw.githubusercontent.com/`.

By specifying `--cdnurl "https://raw.githubusercontent.com/" --cdnrefsep "/"` the CDN can be set to `raw.githubusercontent.com`.
Allows customization of #34.