### PR TITLE
Compatibility with some versions of dvisvgm

### DIFF
--- a/readme2tex/render.py
+++ b/readme2tex/render.py
@@ -177,9 +177,13 @@ def render(
         xml = (ET.fromstring(svg))
         attributes = xml.attrib
         gfill = xml.find('{https://www.w3.org/2000/svg}g')
+        if gfill is None:
+            gfill = xml.find('{http://www.w3.org/2000/svg}g')
         gfill.set('fill-opacity', '0.9')
         if not block:
             uses = gfill.findall('{https://www.w3.org/2000/svg}use')
+            if uses is None:
+                uses = gfill.findall('{http://www.w3.org/2000/svg}use')
             use = uses[0]
             # compute baseline off of this dummy element
             x = use.attrib['x']


### PR DESCRIPTION
In dvisvgm 2.11.1, at least on my machine, the xml namespace is in http:// instead of https://